### PR TITLE
V1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Welcome 
+> This cocos2dx_plugin is to help you easily implement ONEstore IAP v21.01.00 and ALC v2.1.0 in your Cocos2dx project, and provides a guide on how to use it.
+
 # Environment
    ### The environment for this document is as follows:
 

--- a/README.md
+++ b/README.md
@@ -153,23 +153,21 @@
    -keep class com.onestore.**{*;}
    
 8. add dependency in app/build.gradle.
-    dependencies {
-        ...
-        // for ONEstore ALC
-        implementation fileTree(dir: 'onestore/ONEstoreNativeAlcHelper', include: ['*.jar'])
-        def onestore_alc_version = "2.0.0"
-        implementation "com.onestorecorp.sdk:sdk-licensing:$onestore_alc_version"
-        
-        // for ONEstore IAP
-        implementation fileTree(dir: 'onestore/ONEstoreNativeIapHelper', include: ['*.jar'])
-        def onestore_iap_version = "21.00.01"
-        implementation "com.onestorecorp.sdk:sdk-iap:$onestore_iap_version"
+      dependencies {
+         ...
+         // for ALC v2.1.0 & IAP v21.01.00        
 
-        // for ONEstore language set. default set is [kr].
-        def onestore_config_version = "1.0.0"
-        def onestore_config_region = "sdk-configuration-kr"
-        implementation "com.onestorecorp.sdk:$onestore_config_region:$onestore_config_version"        
-        ...
+         // for ONEstore ALC v2.1.0
+         implementation fileTree(dir: 'onestore/ONEstoreNativeAlcHelper', include: ['*.jar'])
+         def onestore_alc_version = "2.1.0"
+         implementation "com.onestorecorp.sdk:sdk-licensing:$onestore_alc_version"
+
+         // for ONEstore IAP v21.01.00  
+         implementation fileTree(dir: 'onestore/ONEstoreNativeIapHelper', include: ['*.jar'])
+         def onestore_iap_version = "21.01.00"
+         implementation "com.onestorecorp.sdk:sdk-iap:$onestore_iap_version"
+
+         ...
     }
 
    


### PR DESCRIPTION
readme 수정.
 dependencies {
         ...
         // for ONEstore ALC v2.1.0
         implementation fileTree(dir: 'onestore/ONEstoreNativeAlcHelper', include: ['*.jar'])
         def onestore_alc_version = "2.1.0"
         implementation "com.onestorecorp.sdk:sdk-licensing:$onestore_alc_version"

         // for ONEstore IAP v21.01.00  
         implementation fileTree(dir: 'onestore/ONEstoreNativeIapHelper', include: ['*.jar'])
         def onestore_iap_version = "21.01.00"
         implementation "com.onestorecorp.sdk:sdk-iap:$onestore_iap_version"

         ...
  }